### PR TITLE
Fixes EmbeddableVideo class by adding attachConstraints method

### DIFF
--- a/src/Plugin/MediaEntity/Type/EmbeddableVideo.php
+++ b/src/Plugin/MediaEntity/Type/EmbeddableVideo.php
@@ -232,4 +232,9 @@ class EmbeddableVideo extends PluginBase implements MediaTypeInterface, Containe
     $property_name = $media->{$source_field}->first()->mainPropertyName();
     return $this->videoProviders->getProviderByEmbedCode($media->{$source_field}->{$property_name});
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function attachConstraints(MediaInterface $media) {}
 }


### PR DESCRIPTION
When you install the latest version of Media Entity + this one you will get this error message:

```
PHP Fatal error:  Class Drupal\media_entity_embeddable_video\Plugin\MediaEntity\Type\EmbeddableVideo contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Drupal\media_entity\MediaTypeInterface::attachConstraints) in modules/contrib/media_entity_embeddable_video/src/Plugin/MediaEntity/Type/EmbeddableVideo.php on line 235
```
