### PR TITLE
Youtube: allows urls without www and adds youtu.be support. Fixes #2605522

### DIFF
--- a/src/Plugin/MediaEntity/VideoProvider/YouTube.php
+++ b/src/Plugin/MediaEntity/VideoProvider/YouTube.php
@@ -18,12 +18,10 @@ use GuzzleHttp\Exception\ClientException;
  *   label = @Translation("YouTube"),
  *   description = @Translation("Provides embedding support for YouTube videos."),
  *   regular_expressions = {
- *     "@(?<protocol>http|https)://www\.youtube(?<cookie>-nocookie)?\.com/embed/(?<id>[a-z0-9_-]+)@i",
- *     "@(?<protocol>http|https)://www\.youtube(?<cookie>-nocookie)?\.com/v/(?<id>[a-z0-9_-]+)@i",
- *     "@(?<protocol>http|https)://www\.youtube(?<cookie>-nocookie)?\.com/watch\?v=(?<id>[a-z0-9_-]+)@i",
- *     "@//www\.youtube(?<cookie>-nocookie)?\.com/embed/(?<id>[a-z0-9_-]+)@i",
- *     "@//www\.youtube(?<cookie>-nocookie)?\.com/v/(?<id>[a-z0-9_-]+)@i",
- *     "@//www\.youtube(?<cookie>-nocookie)?\.com/watch\?v=(?<id>[a-z0-9_-]+)@i"
+ *     "@(?:(?<protocol>http|https):)?//(?:www\.)?youtube(?<cookie>-nocookie)?\.com/embed/(?<id>[a-z0-9_-]+)@i",
+ *     "@(?:(?<protocol>http|https):)?//(?:www\.)?youtube(?<cookie>-nocookie)?\.com/v/(?<id>[a-z0-9_-]+)@i",
+ *     "@(?:(?<protocol>http|https):)?//(?:www\.)?youtube(?<cookie>-nocookie)?\.com/watch\?v=(?<id>[a-z0-9_-]+)@i",
+ *     "@(?:(?<protocol>http|https):)?//youtu(?<cookie>-nocookie)?\.be/(?<id>[a-z0-9_-]+)@i"
  *   }
  * )
  */


### PR DESCRIPTION
I tested the regular expressions with this set of possible youtube urls and they match very well:

```
https://youtube.com/v/qT8YT-e3QBk&index=3&list=WL
http://youtube.com/v/qT8YT-e3QBk&index=3&list=WL
https://www.youtube.com/v/qT8YT-e3QBk&index=3&list=WL
http://www.youtube.com/v/qT8YT-e3QBk&index=3&list=WL
https://www.youtube.com/watch?v=qT8YT-e3QBk&index=3&list=WL
http://www.youtube.com/watch?v=qT8YT-e3QBk&index=3&list=WL
https://www.youtube.com/watch?v=qT8YT-e3QBk
http://www.youtube.com/watch?v=qT8YT-e3QBk
https://youtube.com/watch?v=qT8YT-e3QBk&index=3&list=WL
http://youtube.com/watch?v=qT8YT-e3QBk&index=3&list=WL
https://youtube.com/watch?v=qT8YT-e3QBk
http://youtube.com/watch?v=qT8YT-e3QBk
http://youtu.be/qT8YT-e3QBk
https://youtu.be/qT8YT-e3QBk

//youtube.com/v/qT8YT-e3QBk&index=3&list=WL
//www.youtube.com/v/qT8YT-e3QBk&index=3&list=WL
//www.youtube.com/watch?v=qT8YT-e3QBk&index=3&list=WL
//www.youtube.com/watch?v=qT8YT-e3QBk
//youtube.com/watch?v=qT8YT-e3QBk&index=3&list=WL
//youtube.com/watch?v=qT8YT-e3QBk
//youtu.be/qT8YT-e3QBk

<iframe width="560" height="315" src="https://www.youtube.com/embed/qT8YT-e3QBk" frameborder="0" allowfullscreen></iframe>
<iframe width="560" height="315" src="https://youtube.com/embed/qT8YT-e3QBk" frameborder="0" allowfullscreen></iframe>
<iframe width="560" height="315" src="//www.youtube.com/embed/qT8YT-e3QBk" frameborder="0" allowfullscreen></iframe>
<iframe width="560" height="315" src="//youtube.com/embed/qT8YT-e3QBk" frameborder="0" allowfullscreen></iframe>
```
