### PR TITLE
Fixing YouTube fallback thumbnail

### DIFF
--- a/src/Plugin/MediaEntity/VideoProvider/YouTube.php
+++ b/src/Plugin/MediaEntity/VideoProvider/YouTube.php
@@ -98,7 +98,7 @@ class YouTube extends VideoProviderBase implements VideoProviderInterface {
    * {@inheritdoc}
    */
   public function thumbnailURI() {
-    $thumbnail = 'http://img.youtube.com/vi/[video_id]/hqdefault.jpg';
+    $thumbnail = 'http://img.youtube.com/vi/' . $this->matches['id'] .'/hqdefault.jpg';
 
     if ($this->apiKey) {
       $options = [


### PR DESCRIPTION
The fallback thumbnail is not working. This change fixes that.
