### PR TITLE
Issue #2606626 fix dependency with media_entity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ install:
   - drupal-ti install
 
 before_script:
-  - DRUPAL_TI_MODULE_NAME='media_entity' drupal-ti drupal_ti_ensure_module
+  - drupal-ti drupal_ti_ensure_module
   - drupal-ti before_script
 
 script:


### PR DESCRIPTION
I think we should not override module global name DRUPAL_TI_MODULE_NAME
